### PR TITLE
encode return value as integer instead of string

### DIFF
--- a/in-toto-spec.md
+++ b/in-toto-spec.md
@@ -909,7 +909,7 @@ The format of the `[name].[KEYID-PREFIX].link` file is as follows:
   "byproducts": {
     "stderr": "",
     "stdout": "",
-    "return-value": ""
+    "return-value": null
   },
   "environment": {
     "variables": "<ENV>",
@@ -935,7 +935,8 @@ information about the step performed. Byproducts are not verified by in-toto’s
 default verification routine. However, the information gathered can be used for
 further scrutiny during an inspection step. At a minimum, the byproducts
 dictionary should have standard output (stdout), standard error (stderr) and
-return value (return-value), even if no values are filled in.
+return value (return-value), even if no values are filled in. The return value
+should be stored as integer value.
 
 Finally, the environment dictionary contains information about the environment
 in which the step was carried out. Although the environment dictionary is an
@@ -1233,7 +1234,7 @@ metadata:
     "byproducts": {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1267,7 +1268,7 @@ metadata:
     "byproducts": {
       "stderr": "",
       "stdout": "foo.py",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1432,7 +1433,7 @@ metadata:
     "byproducts": {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1465,7 +1466,7 @@ metadata:
     "byproducts": {
       "stderr": "",
       "stdout": "....\nOk",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1501,7 +1502,7 @@ looks really similar (modulo the signature and the filename).
     "byproducts": {
       "stderr": "",
       "stdout": "foo.py",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1685,11 +1686,10 @@ link metadata:
        "src/foo.c": { "sha256": "2a0ffef5e9709e6164c629e8b31bae0d..."},
        "vcs.log": { "sha256": "e64589ab156f325a4ab2bc5d532737d5a7..."}
     },
-    "return-value": "0",
     "byproducts": {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
      },
     "environment": {
       "variables": [""],
@@ -1723,7 +1723,7 @@ link metadata:
     "byproducts": {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
      },
     "environment": {
       "variables": [""],
@@ -1756,7 +1756,7 @@ link metadata:
     "byproducts":  {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1928,7 +1928,7 @@ A root.layout file that fulfills these requirements would look like this:
     "byproducts":  {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -1961,7 +1961,7 @@ A root.layout file that fulfills these requirements would look like this:
     "byproducts":  {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
      },
     "environment": {
       "variables": [""],
@@ -1994,7 +1994,7 @@ A root.layout file that fulfills these requirements would look like this:
     "byproducts": {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -2027,7 +2027,7 @@ A root.layout file that fulfills these requirements would look like this:
     "byproducts":  {
      "stderr": "",
      "stdout": "",
-     "return-value": "0"
+     "return-value": 0
     },
     "environment": {
       "variables": [""],
@@ -2060,7 +2060,7 @@ A root.layout file that fulfills these requirements would look like this:
     "byproducts":  {
       "stderr": "",
       "stdout": "",
-      "return-value": "0"
+      "return-value": 0
     },
     "environment": {
       "variables": [""],


### PR DESCRIPTION
The in-toto python reference implementation encodes the return-value
field of our link files as integer. Our specification specified this
field as string value. This commit fixes this inconsistency and
assigns the right data type to the return-value field.

CC: @SantiagoTorres @lukpueh @trishankatdatadog 