### PR TITLE
Add _type to step definition

### DIFF
--- a/in-toto-spec.md
+++ b/in-toto-spec.md
@@ -618,7 +618,8 @@ verification. We will elaborate on the specifics of this process in section
 Steps performed by a functionary in the supply chain are declared as follows:
 
 ```json
-{ "name": "<NAME>",
+{ "_type": "step",
+  "name": "<NAME>",
   "threshold": "<THRESHOLD>",
   "expected_materials": [
      [ "<ARTIFACT_RULE>" ],


### PR DESCRIPTION
The Step definition is missing the `_type` field that is included in examples and both the python and go implementations.

Signed-off-by: Brandon Mitchell <git@bmitch.net>