### PR TITLE
Mark specification v1.0

### DIFF
--- a/in-toto-spec.md
+++ b/in-toto-spec.md
@@ -1,10 +1,10 @@
 ﻿# in-toto Specification
 
-Apr 02, 2023
+Jun 02, 2023
 
 <https://in-toto.io>
 
-Version 1.0-RC
+Version 1.0.0
 
 ## Table of Contents
 


### PR DESCRIPTION
Removes the RC moniker and prepares specification for v1.0.

Fixes #46 