### PR TITLE
Remove link to web layout tool live instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ brief description.
   occurrences, and back for use in an in-toto verification workflow.
 - [layout-web-tool](https://github.com/in-toto/layout-web-tool): The
   layout-web-tool is a simple Flask-based web app that walks users through
-  creating an in-toto layout. This tool is
-  [hosted](https://in-toto.engineering.nyu.edu/) for interested project owners
-  to try out.
-
+  creating an in-toto layout.
 
 ## Other informative repositories
 


### PR DESCRIPTION
The live instance of the layout web tool has been taken offline, while updating dependencies and fixing issues. This commit removes the related link.